### PR TITLE
Make SOUR references work like GEDCOM 5.5 says they should

### DIFF
--- a/library/PhpGedcom/Parser/SourRef.php
+++ b/library/PhpGedcom/Parser/SourRef.php
@@ -75,6 +75,10 @@ class SourRef extends \PhpGedcom\Parser\Component
                     $even = \PhpGedcom\Parser\SourRef\Even::parse($parser);
                     $sour->setEven($even);
                     break;
+                case 'OBJE':
+                    $obje = \PhpGedcom\Parser\ObjeRef::parse($parser);
+                    $sour->addObje($obje);
+                    break;
                 default:
                     $parser->logUnhandledRecord(get_class() . ' @ ' . __LINE__);
                 }

--- a/library/PhpGedcom/Record/SourRef.php
+++ b/library/PhpGedcom/Record/SourRef.php
@@ -30,4 +30,20 @@ class SourRef extends \PhpGedcom\Record
     
     protected $_obje    = array();
     protected $_note    = array();
+
+    /**
+     *
+     */
+    public function setIsReference($isReference = true)
+    {
+        $this->_isRef = $isReference;
+    }
+    
+    /**
+     *
+     */
+    public function getIsReference()
+    {
+        return $this->_isRef;
+    }
 }


### PR DESCRIPTION
This pull request should make the SourRef parser conform to the [source citation documentation](http://homepages.rootsweb.ancestry.com/~pmcbride/gedcom/55gcch2.htm#SOURCE_CITATION) here. 

Cases where a source is a reference are now handled differently than inline sources. In addition, OBJE support was absent from from SourRef while the spec says it should be supported. 

This would also close issue #15. In the case of #15, the SOUR is detected as a reference and the CONC tags are sent to logUnhandledRecord.
