### PR TITLE
Fix duplicated class names

### DIFF
--- a/library/PhpGedcom/Record/Fam/Anul.php
+++ b/library/PhpGedcom/Record/Fam/Anul.php
@@ -7,7 +7,7 @@
  *
  * @author          Kristopher Wilson <kristopherwilson@gmail.com>
  * @copyright       Copyright (c) 2010-2013, Kristopher Wilson
- * @package         php-gedcom 
+ * @package         php-gedcom
  * @license         GPL-3.0
  * @link            http://github.com/mrkrstphr/php-gedcom
  */
@@ -17,6 +17,6 @@ namespace PhpGedcom\Record\Fam;
 /**
  *
  */
-class Marr extends \PhpGedcom\Record\Fam\Even
+class Anul extends \PhpGedcom\Record\Fam\Even
 {
 }

--- a/library/PhpGedcom/Record/Fam/Cens.php
+++ b/library/PhpGedcom/Record/Fam/Cens.php
@@ -7,7 +7,7 @@
  *
  * @author          Kristopher Wilson <kristopherwilson@gmail.com>
  * @copyright       Copyright (c) 2010-2013, Kristopher Wilson
- * @package         php-gedcom 
+ * @package         php-gedcom
  * @license         GPL-3.0
  * @link            http://github.com/mrkrstphr/php-gedcom
  */
@@ -17,6 +17,6 @@ namespace PhpGedcom\Record\Fam;
 /**
  *
  */
-class Marr extends \PhpGedcom\Record\Fam\Even
+class Cens extends \PhpGedcom\Record\Fam\Even
 {
 }

--- a/library/PhpGedcom/Record/Fam/Div.php
+++ b/library/PhpGedcom/Record/Fam/Div.php
@@ -7,7 +7,7 @@
  *
  * @author          Kristopher Wilson <kristopherwilson@gmail.com>
  * @copyright       Copyright (c) 2010-2013, Kristopher Wilson
- * @package         php-gedcom 
+ * @package         php-gedcom
  * @license         GPL-3.0
  * @link            http://github.com/mrkrstphr/php-gedcom
  */
@@ -17,6 +17,6 @@ namespace PhpGedcom\Record\Fam;
 /**
  *
  */
-class Marr extends \PhpGedcom\Record\Fam\Even
+class Div extends \PhpGedcom\Record\Fam\Even
 {
 }

--- a/library/PhpGedcom/Record/Fam/Enga.php
+++ b/library/PhpGedcom/Record/Fam/Enga.php
@@ -7,7 +7,7 @@
  *
  * @author          Kristopher Wilson <kristopherwilson@gmail.com>
  * @copyright       Copyright (c) 2010-2013, Kristopher Wilson
- * @package         php-gedcom 
+ * @package         php-gedcom
  * @license         GPL-3.0
  * @link            http://github.com/mrkrstphr/php-gedcom
  */
@@ -17,6 +17,6 @@ namespace PhpGedcom\Record\Fam;
 /**
  *
  */
-class Marr extends \PhpGedcom\Record\Fam\Even
+class Enga extends \PhpGedcom\Record\Fam\Even
 {
 }

--- a/library/PhpGedcom/Record/Fam/Marb.php
+++ b/library/PhpGedcom/Record/Fam/Marb.php
@@ -7,7 +7,7 @@
  *
  * @author          Kristopher Wilson <kristopherwilson@gmail.com>
  * @copyright       Copyright (c) 2010-2013, Kristopher Wilson
- * @package         php-gedcom 
+ * @package         php-gedcom
  * @license         GPL-3.0
  * @link            http://github.com/mrkrstphr/php-gedcom
  */
@@ -17,6 +17,6 @@ namespace PhpGedcom\Record\Fam;
 /**
  *
  */
-class Marr extends \PhpGedcom\Record\Fam\Even
+class Marb extends \PhpGedcom\Record\Fam\Even
 {
 }

--- a/library/PhpGedcom/Record/Fam/Marc.php
+++ b/library/PhpGedcom/Record/Fam/Marc.php
@@ -7,7 +7,7 @@
  *
  * @author          Kristopher Wilson <kristopherwilson@gmail.com>
  * @copyright       Copyright (c) 2010-2013, Kristopher Wilson
- * @package         php-gedcom 
+ * @package         php-gedcom
  * @license         GPL-3.0
  * @link            http://github.com/mrkrstphr/php-gedcom
  */
@@ -17,6 +17,6 @@ namespace PhpGedcom\Record\Fam;
 /**
  *
  */
-class Marr extends \PhpGedcom\Record\Fam\Even
+class Marc extends \PhpGedcom\Record\Fam\Even
 {
 }

--- a/library/PhpGedcom/Record/Fam/Marl.php
+++ b/library/PhpGedcom/Record/Fam/Marl.php
@@ -7,7 +7,7 @@
  *
  * @author          Kristopher Wilson <kristopherwilson@gmail.com>
  * @copyright       Copyright (c) 2010-2013, Kristopher Wilson
- * @package         php-gedcom 
+ * @package         php-gedcom
  * @license         GPL-3.0
  * @link            http://github.com/mrkrstphr/php-gedcom
  */
@@ -17,6 +17,6 @@ namespace PhpGedcom\Record\Fam;
 /**
  *
  */
-class Marr extends \PhpGedcom\Record\Fam\Even
+class Marl extends \PhpGedcom\Record\Fam\Even
 {
 }

--- a/library/PhpGedcom/Record/Fam/Mars.php
+++ b/library/PhpGedcom/Record/Fam/Mars.php
@@ -7,7 +7,7 @@
  *
  * @author          Kristopher Wilson <kristopherwilson@gmail.com>
  * @copyright       Copyright (c) 2010-2013, Kristopher Wilson
- * @package         php-gedcom 
+ * @package         php-gedcom
  * @license         GPL-3.0
  * @link            http://github.com/mrkrstphr/php-gedcom
  */
@@ -17,6 +17,6 @@ namespace PhpGedcom\Record\Fam;
 /**
  *
  */
-class Marr extends \PhpGedcom\Record\Fam\Even
+class Mars extends \PhpGedcom\Record\Fam\Even
 {
 }


### PR DESCRIPTION
When I run `composer dump-autoload --optimize` in a project that includes  php-gedcom library via composer.json I get for almost all classes under `library/PhpGedcom/Record/Fam` this error:
```
Ambiguous class resolution, "PhpGedcom\Record\Fam\Marr"
```

It looks like these classes are not really used at all, but if the class PhpGedcom\Record\Fam\Marr is used it could result in unexpected behavior as the wrong implementation could be loaded.

This fixes the class names.