### PR TITLE
DateTime for dates

### DIFF
--- a/library/PhpGedcom/Parser/Fam/Even.php
+++ b/library/PhpGedcom/Parser/Fam/Even.php
@@ -54,7 +54,7 @@ class Even extends \PhpGedcom\Parser\Component
                     $even->setType(trim($record[2]));
                     break;
                 case 'DATE':
-                    $even->setDate(trim($record[2]));
+                    $even->setDate(new \DateTime(trim($record[2])));
                     break;
                 case 'PLAC':
                     $plac = \PhpGedcom\Parser\Indi\Even\Plac::parse($parser);

--- a/library/PhpGedcom/Parser/Indi/Attr.php
+++ b/library/PhpGedcom/Parser/Indi/Attr.php
@@ -57,7 +57,7 @@ abstract class Attr extends \PhpGedcom\Parser\Component
                     $attr->setType(trim($record[2]));
                     break;
                 case 'DATE':
-                    $attr->setDate(trim($record[2]));
+                    $attr->setDate(new \DateTime(trim($record[2])));
                     break;
                 case 'PLAC':
                     $plac = \PhpGedcom\Parser\Indi\Even\Plac::parse($parser);

--- a/library/PhpGedcom/Parser/Indi/Even.php
+++ b/library/PhpGedcom/Parser/Indi/Even.php
@@ -63,7 +63,7 @@ class Even extends \PhpGedcom\Parser\Component
                     $even->setType(trim($record[2]));
                     break;
                 case 'DATE':
-                    $even->setDate(trim($record[2]));
+                    $even->setDate(new \DateTime(trim($record[2])));
                     break;
                 case 'PLAC':
                     $plac = \PhpGedcom\Parser\Indi\Even\Plac::parse($parser);


### PR DESCRIPTION
Parsed dates are now PHP DateTime objects instead of strings.